### PR TITLE
Unique IDs for ToDirectory and impproved logging of failed sensors

### DIFF
--- a/HWInfoPlugin.cs
+++ b/HWInfoPlugin.cs
@@ -76,14 +76,14 @@ namespace FanControl.HWInfo
             {
                 if (++_updateFailCount >= 10)
                 {
-                    var names = String.Join(", ", result.MissingSensors.Select(x => x.Name));
+                    var IDs = String.Join(", ", result.MissingSensors.Select(x => x.Id));
                     Close();
-                    throw new Exception($"HWInfo sensor value went missing from registry: {names}");
+                    throw new Exception($"HWInfo sensor value went missing from registry: {IDs}");
                 }
                 else
                 {
-                    var names = String.Join(", ", result.MissingSensors.Select(x => x.Name));
-                    System.IO.File.AppendAllText("log.txt", Environment.NewLine + DateTime.Now + ": " + $"HWInfo sensor value went missing from registry: {names}");
+                    var IDs = String.Join(", ", result.MissingSensors.Select(x => x.Id));
+                    System.IO.File.AppendAllText("log.txt", Environment.NewLine + DateTime.Now + ": " + $"HWInfo sensor value went missing from registry: {IDs}");
                 }
             }
             else

--- a/HWInfoPlugin.cs
+++ b/HWInfoPlugin.cs
@@ -83,7 +83,7 @@ namespace FanControl.HWInfo
                 else
                 {
                     var IDs = String.Join(", ", result.MissingSensors.Select(x => x.Id));
-                    System.IO.File.AppendAllText("log.txt", Environment.NewLine + DateTime.Now + ": " + $"HWInfo sensor value went missing from registry: {IDs}");
+                    _logger.Log($"HWInfo sensor value went missing from registry: {IDs}");
                 }
             }
             else

--- a/HWInfoPlugin.cs
+++ b/HWInfoPlugin.cs
@@ -80,6 +80,11 @@ namespace FanControl.HWInfo
                     Close();
                     throw new Exception($"HWInfo sensor value went missing from registry: {names}");
                 }
+                else
+                {
+                    var names = String.Join(", ", result.MissingSensors.Select(x => x.Name));
+                    System.IO.File.AppendAllText("log.txt", Environment.NewLine + DateTime.Now + ": " + $"HWInfo sensor value went missing from registry: {names}");
+                }
             }
             else
             {

--- a/HWInfoPlugin.cs
+++ b/HWInfoPlugin.cs
@@ -76,14 +76,14 @@ namespace FanControl.HWInfo
             {
                 if (++_updateFailCount >= 10)
                 {
-                    var IDs = String.Join(", ", result.MissingSensors.Select(x => x.Id));
+                    var ids = String.Join(", ", result.MissingSensors.Select(x => x.Id));
                     Close();
-                    throw new Exception($"HWInfo sensor value went missing from registry: {IDs}");
+                    throw new Exception($"HWInfo sensor value went missing from registry: {ids}");
                 }
                 else
                 {
-                    var IDs = String.Join(", ", result.MissingSensors.Select(x => x.Id));
-                    _logger.Log($"HWInfo sensor value went missing from registry: {IDs}");
+                    var ids = String.Join(", ", result.MissingSensors.Select(x => x.Id));
+                    _logger.Log($"HWInfo sensor value went missing from registry: {ids}");
                 }
             }
             else

--- a/HWInfoRegistry.cs
+++ b/HWInfoRegistry.cs
@@ -144,7 +144,7 @@ namespace FanControl.HWInfo
             var sensor = subKey.GetValue(SENSOR_REGISTRY_NAME + index);
             var label = subKey.GetValue(LABEL_REGISTRY_NAME + index);
 
-            return $"HWInfo/{sensor}/{label}";
+            return $"HWInfo/{sensor}/{label}/{(((string)subKey.GetValue(VALUE_REGISTRY_NAME + index)).Trim().Split(' ').Skip(1).FirstOrDefault() ?? string.Empty).ToUpperInvariant()}";
         }
     }
 }

--- a/HWInfoRegistry.cs
+++ b/HWInfoRegistry.cs
@@ -143,8 +143,9 @@ namespace FanControl.HWInfo
         {
             var sensor = subKey.GetValue(SENSOR_REGISTRY_NAME + index);
             var label = subKey.GetValue(LABEL_REGISTRY_NAME + index);
+            var unit = (((string)subKey.GetValue(VALUE_REGISTRY_NAME + index)).Trim().Split(' ').Skip(1).FirstOrDefault() ?? string.Empty).ToUpperInvariant();
 
-            return $"HWInfo/{sensor}/{label}/{(((string)subKey.GetValue(VALUE_REGISTRY_NAME + index)).Trim().Split(' ').Skip(1).FirstOrDefault() ?? string.Empty).ToUpperInvariant()}";
+            return $"HWInfo/{sensor}/{label}/{unit}";
         }
     }
 }


### PR DESCRIPTION
This seems to work very well, please review and accept if you're OK with my changes.

The ID can never be guaranteed unique, but with my changes, it's as unique as it gets I guess. Works well on my system with a few sensors with identical names and labels, adding the unit type to the ID made it unique.

I'm writing to the log every time a sensor is "lost", or the user will never know, and this is certainly useful info.

I'm also using the ID and not the name, both for logging and in the exception, as this is unique and makes it easier to pinpoint exactly which sensor was missing.
