### PR TITLE
Add support for HWiNFO32

### DIFF
--- a/HWInfoRegistry.cs
+++ b/HWInfoRegistry.cs
@@ -15,6 +15,7 @@ namespace FanControl.HWInfo
         const string VALUE_REGISTRY_NAME = "Value";
         const string VALUE_RAW_REGISTRY_NAME = "ValueRaw";
         const string MAIN_KEY = @"SOFTWARE\HWiNFO64\VSB";
+        const string SECOND_KEY = @"SOFTWARE\HWiNFO32\VSB";
 
         private RegistryKey _key;
         private int _count;
@@ -22,6 +23,8 @@ namespace FanControl.HWInfo
         public HWInfoRegistry()
         {
             _key = Registry.CurrentUser.OpenSubKey(MAIN_KEY);
+            if (_key == null)
+                _key = Registry.CurrentUser.OpenSubKey(SECOND_KEY);
             _count = _key?.ValueCount ?? 0;
         }
 

--- a/HWInfoRegistry.cs
+++ b/HWInfoRegistry.cs
@@ -22,9 +22,7 @@ namespace FanControl.HWInfo
 
         public HWInfoRegistry()
         {
-            _key = Registry.CurrentUser.OpenSubKey(MAIN_KEY);
-            if (_key == null)
-                _key = Registry.CurrentUser.OpenSubKey(SECOND_KEY);
+            _key = Registry.CurrentUser.OpenSubKey(MAIN_KEY) ?? Registry.CurrentUser.OpenSubKey(SECOND_KEY);
             _count = _key?.ValueCount ?? 0;
         }
 


### PR DESCRIPTION
If both are running, this will use the values from HWiNFO64.

I have been testing this and it appears to work fine. I had some issues with it displaying 0 on all the values but that went away after a restart.